### PR TITLE
chore: Update SonarQube to SonarQube Cloud in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,18 +6,18 @@ on:
       - master
 
 jobs:
-  SonarQube:
-    name: SonarQube
+  sonarcloud:
+    name: SonarQube Cloud
     runs-on: ubuntu-latest
-    permissions: read-all
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: sonarsource/sonarqube-scan-action@master
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
   bump-version:
     if: "!contains(github.event.head_commit.message, '[skip-ci]')"
     runs-on: [ubuntu-latest]

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,14 +3,15 @@ name: PR Test
 on: pull_request
 
 jobs:
-  sonarqube:
-    name: Build and analyze
+  sonarcloud:
+    name: SonarQube Cloud
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: sonarsource/sonarqube-scan-action@master
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,3 @@
-sonar.projectKey=XargsUK_checkov-prismaless-vscode_12b90eea-14af-4878-8729-551568bb0b27
+sonar.projectKey=XargsUK_checkov-prismaless-vscode
+sonar.organization=xargsuk
+sonar.projectName=checkov-prismaless-vscode


### PR DESCRIPTION
This pull request includes changes to update the CI/CD workflows to use SonarQube Cloud instead of the on-premises SonarQube. The most important changes include renaming job identifiers, updating the action used for SonarQube scanning, and modifying environment variables.

Updates to CI/CD workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L9-L20): Renamed the job from `SonarQube` to `sonarcloud`, updated the action to `SonarSource/sonarcloud-github-action@master`, and added the `GITHUB_TOKEN` environment variable.
* [`.github/workflows/pr-test.yml`](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL6-L16): Renamed the job from `sonarqube` to `sonarcloud`, updated the action to `SonarSource/sonarcloud-github-action@master`, and added the `GITHUB_TOKEN` environment variable.