### PR TITLE
Fix: add version cache, handle for latest without version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   bump-version:
-    if: "!contains(github.event.head_commit.message, '[skip-ci]')"
+    if: '!contains(github.event.head_commit.message, "[skip-ci]")'
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@master

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
       {
         "command": "checkov-prismaless.clear-results-cache",
         "title": "Clear Checkov results cache"
+      },
+      {
+        "command": "checkov-prismaless.clear-version-cache",
+        "title": "Clear Checkov version cache"
       }
     ],
     "configuration": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,3 +6,4 @@ export const INSTALL_OR_UPDATE_CHECKOV_COMMAND = 'checkov-prismaless.install-or-
 export const GET_INSTALLATION_DETAILS_COMMAND = 'checkov-prismaless.about-checkov';
 export const OPEN_CHECKOV_LOG = 'checkov-prismaless.open-log';
 export const CLEAR_RESULTS_CACHE = 'checkov-prismaless.clear-results-cache';
+export const CLEAR_VERSION_CACHE = 'checkov-prismaless.clear-version-cache';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,9 +9,12 @@ import { initializeStatusBarItem, setErrorStatusBarItem, setPassedStatusBarItem,
 import { getCheckovVersion, shouldDisableErrorMessage, getPathToCert, getUseBcIds, getUseDebugLogs, getExternalChecksDir, getNoCertVerify, getSkipFrameworks, getFrameworks } from './configuration';
 import { CLEAR_RESULTS_CACHE, GET_INSTALLATION_DETAILS_COMMAND, INSTALL_OR_UPDATE_CHECKOV_COMMAND, OPEN_CHECKOV_LOG, OPEN_CONFIGURATION_COMMAND, OPEN_EXTERNAL_COMMAND, REMOVE_DIAGNOSTICS_COMMAND, RUN_FILE_SCAN_COMMAND } from './commands';
 import { getConfigFilePath } from './parseCheckovConfig';
+import { clearVersionCache } from './checkov/checkovInstaller';
 
 export const CHECKOV_MAP = 'checkovMap';
 const logFileName = 'checkov.log';
+
+export const CLEAR_VERSION_CACHE = 'checkov-prismaless.clear-version-cache';
 
 // this method is called when extension is activated
 export function activate(context: vscode.ExtensionContext): void {
@@ -95,6 +98,13 @@ export function activate(context: vscode.ExtensionContext): void {
         }),
         vscode.commands.registerCommand(CLEAR_RESULTS_CACHE, async () => {
             clearCache(context, logger);
+        }),
+        vscode.commands.registerCommand(CLEAR_VERSION_CACHE, async () => {
+            clearVersionCache();
+            logger.info('Checkov version cache cleared');
+            vscode.window.showInformationMessage('Checkov version cache cleared');
+            // Re-run the installation to get a fresh version
+            vscode.commands.executeCommand(INSTALL_OR_UPDATE_CHECKOV_COMMAND);
         })
     );
 


### PR DESCRIPTION
This pull request includes multiple changes to enhance the Checkov installation and version management process, as well as updates to the Visual Studio Code extension commands. The most important changes include the introduction of a version cache for Docker installations, the addition of a new command to clear this cache, and updates to the status bar to display the actual Checkov version.

Enhancements to Checkov installation and version management:

* [`src/checkov/checkovInstaller.ts`](diffhunk://#diff-66e86143902be25ebf6b76b2cec71559720c197227c8d7e4a8c9d9b92dd99c76L109-R218): Introduced a version cache for Docker installations to optimize version resolution and added methods to manage this cache. [[1]](diffhunk://#diff-66e86143902be25ebf6b76b2cec71559720c197227c8d7e4a8c9d9b92dd99c76L109-R218) [[2]](diffhunk://#diff-66e86143902be25ebf6b76b2cec71559720c197227c8d7e4a8c9d9b92dd99c76R236-R239)
* [`src/checkov/checkovRunner.ts`](diffhunk://#diff-18d18bc9fbc8c8ae00597f5b16416700bcec08874c78ea9952d0e994810a514eL36-R36): Updated Docker run parameters to use the resolved Checkov version from the cache. [[1]](diffhunk://#diff-18d18bc9fbc8c8ae00597f5b16416700bcec08874c78ea9952d0e994810a514eL36-R36) [[2]](diffhunk://#diff-18d18bc9fbc8c8ae00597f5b16416700bcec08874c78ea9952d0e994810a514eL64-R74)

Updates to Visual Studio Code extension commands:

* [`src/commands.ts`](diffhunk://#diff-ca92d1afe836a483259dfc56e55ada3e33076f195fd4f2e7a0fd06be4bfa664fR9): Added a new command `CLEAR_VERSION_CACHE` to clear the version cache.
* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R12-R18): Registered the new command and updated the status bar to display the actual Checkov version. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R12-R18) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L42-R53) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L57-R69) [[4]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L78-R85) [[5]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R105-R111) [[6]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L116-R130) [[7]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L125-R139) [[8]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L144) [[9]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L165-R185) [[10]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L181-R201) [[11]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L197-R210)

Minor configuration changes:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L22-R22): Fixed syntax for the `if` condition in the `bump-version` job.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R59-R62): Added a new command to clear the Checkov version cache.

fixes #13 