### PR TITLE
fix skipChecks overriding config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ The Checkov extension will invoke the latest version of ```Checkov```.
 * Click a scan to see its details. Details will include the violating policy and a link to step-by-step fix guidelines.
 * In most cases, the Details will include a fix option. This will either add, remove or replace an unwanted configuration, based on the Checkov fix dictionaries.
 * You can skip checks by adding an inline skip annotation ```checkov:skip=<check_id>:<suppression_comment>```.
-* You can skip checks for the whole workspace by adding a `.checkov.yaml` in your workspace folder (see [Checkov Configuration file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file)).
-* You can override certain configuration values by using the extension settings (`framework`, `skip-framework`, `skip-check`).
-* The extension will continue *to* scan file modifications and highlight errors in your editor upon every material resource modification.
+* You can skip checks for the whole workspace by adding a `.checkov.yaml` in your workspace folder (see [Checkov Configuration file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file)). You can also override certain configuration values by using the extension settings (`framework`, `skip-framework`, `skip-check`). By default, whenever you edit your checkov config file or override the values using the extension settings, the checkov cache will be cleared - this behaviour can be deisable .
+* The extension will continue to scan file modifications and highlight errors in your editor upon every material resource modification.
 
 ### Troubleshooting logs
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Checkov](https://github.com/bridgecrewio/checkov) is an open-source static code analysis tool for infrastructure-as-code, secrets, and software composition analysis.
 
-This extension is a fork of the original Bridgecrew extension, with the removal of the PrismaCloud API dependencies. This forked extension can be found on the [Visual Studio Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=XargsUK.checkov-prismaless) and its source code is available in an [Apache 2.0 licensed repository](https://github.com/XargsUK/checkov-prismaless-vscode).  The original extension can be found on the [Visual Studio Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=Bridgecrew.checkov) and its source code is available in an [Apache 2.0 licensed repository](https://github.com/bridgecrewio/checkov-vscode). This extension is downstream from the original extension. 
+This extension is a fork of the original Bridgecrew extension, with the removal of the PrismaCloud API dependencies. This forked extension can be found on the [Visual Studio Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=XargsUK.checkov-prismaless) and its source code is available in an [Apache 2.0 licensed repository](https://github.com/XargsUK/checkov-prismaless-vscode).  The original extension can be found on the [Visual Studio Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=Bridgecrew.checkov) and its source code is available in an [Apache 2.0 licensed repository](https://github.com/bridgecrewio/checkov-vscode). This extension is downstream from the original extension.
 
 The Checkov Extension for Visual Studio Code enables developers to get real-time scan results, as well as inline fix suggestions as they develop cloud infrastructure.
 
@@ -23,14 +23,13 @@ Extension features include:
 
 ### Install
 
-Open the CheckovPrismaless Extension for Visual Studio Code in the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=XargsUK.checkov-prismaless) and install. 
+Open the CheckovPrismaless Extension for Visual Studio Code in the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=XargsUK.checkov-prismaless) and install.
 
 ### Dependencies
 
 * [Python](https://www.python.org/downloads/) >= 3.7 or [Pipenv](https://docs.pipenv.org/) or [Docker](https://www.docker.com/products/docker-desktop) daemon running
 
 The Checkov extension will invoke the latest version of ```Checkov```.
-
 
 ### Usage
 
@@ -40,11 +39,14 @@ The Checkov extension will invoke the latest version of ```Checkov```.
 * Click a scan to see its details. Details will include the violating policy and a link to step-by-step fix guidelines.
 * In most cases, the Details will include a fix option. This will either add, remove or replace an unwanted configuration, based on the Checkov fix dictionaries.
 * You can skip checks by adding an inline skip annotation ```checkov:skip=<check_id>:<suppression_comment>```.
-* The extension will continue to scan file modifications and highlight errors in your editor upon every material resource modification.
+* You can skip checks for the whole workspace by adding a `.checkov.yaml` in your workspace folder (see [Checkov Configuration file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file)).
+* You can override certain configuration values by using the extension settings (`framework`, `skip-framework`, `skip-check`).
+* The extension will continue *to* scan file modifications and highlight errors in your editor upon every material resource modification.
 
 ### Troubleshooting logs
 
 To access the checkov-prismaless-vscode logs directory, open the VS Code Command Palette `(Ctrl+Shift+P)` or `(Command+Shift+P)`, and run the command `Open Checkov Log`. It is helpful to delete the log file and then retry whichever operation failed to produce clean logs.
 
 ### Why Create this Fork?
+
 I detailed the reasons for creating this fork in a [Medium Article](https://medium.com/aws-in-plain-english/checkov-de-prismafying-the-vscode-extension-for-local-security-scans-c33aa35f5b35). The main reasons were to remove the PrismaCloud API dependencies once the Bridgecrew API was deprecated. Checkov is an excellent tool and I wanted to ensure that the Visual Studio Code extension was still available for the community to use.

--- a/package.json
+++ b/package.json
@@ -89,12 +89,17 @@
         },
         "checkov-prismaless.skipFrameworks": {
           "title": "Skip Frameworks",
-          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless').\nAdd multiple frameworks using spaces.\nSee [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.\nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
+          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless'). Add multiple frameworks using spaces. See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.  \nSetting this configuration property will overide any `skip-framework` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file).",
           "type": "string"
         },
         "checkov-prismaless.frameworks": {
           "title": "Frameworks",
-          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless').\nAdd multiple frameworks using spaces.\nSee [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.\nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.",
+          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless'). Add multiple frameworks using spaces.  \nSee [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.  \nSetting this configuration property will overide any `framework` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file).",
+          "type": "string"
+        },
+        "checkov-prismaless.skipChecks": {
+          "title": "Skip Checks",
+          "markdownDescription": "Filter scan to run all checks except those listed (deny list). Add multiple checks using comma separated values \nSetting this configuration property will overide any `skip-check` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file). ",
           "type": "string"
         }
       }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,12 @@
           "type": "boolean",
           "default": false
         },
+        "checkov-prismaless.clearCacheUponConfigUpdate": {
+          "title": "Clear cache upon config update",
+          "markdownDescription": "Clear the Checkov extension results cache when the Checkov configuration is updated. This ensures consistant results but will require Checkov to re-scan all files.",
+          "type": "boolean",
+          "default": true
+        },
         "checkov-prismaless.useDebugLogs": {
           "title": "Use debug logs",
           "markdownDescription": "Whether to print debug logs from Checkov for troubleshooting",
@@ -89,12 +95,12 @@
         },
         "checkov-prismaless.skipFrameworks": {
           "title": "Skip Frameworks",
-          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless'). Add multiple frameworks using spaces. See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.  \nSetting this configuration property will overide any `skip-framework` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file).",
+          "markdownDescription": "Filter scan to skip specific frameworks (e.g., 'arm json secrets serverless'). Add multiple frameworks using spaces. See [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \nSetting this configuration property will overide any `skip-framework` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file).",
           "type": "string"
         },
         "checkov-prismaless.frameworks": {
           "title": "Frameworks",
-          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless'). Add multiple frameworks using spaces.  \nSee [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \nYou may need to run the extension command 'Clear Checkov results cache' after modifying this setting.  \nSetting this configuration property will overide any `framework` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file).",
+          "markdownDescription": "Filter scan to run only on specific frameworks (e.g., 'arm json secrets serverless'). Add multiple frameworks using spaces.  \nSee [Checkov Frameworks](https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html) for more information.  \nSetting this configuration property will overide any `framework` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file).",
           "type": "string"
         },
         "checkov-prismaless.skipChecks": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,6 +36,12 @@ export const getSkipFrameworks = (): string[] | undefined => {
     return skipFrameworks ? skipFrameworks.split(' ').map(entry => entry.trim()) : undefined;
 };
 
+export const getSkipChecks = (): string[] | undefined => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov-prismaless');
+    const skipChecks = configuration.get<string>('skipChecks');
+    return skipChecks ? skipChecks.split(' ').map(entry => entry.trim()) : undefined;
+};
+
 export const getFrameworks = (): string[] | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov-prismaless');
     const frameworks = configuration.get<string>('frameworks');

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -102,6 +102,12 @@ export const shouldDisableErrorMessage = (): boolean => {
     return disableErrorMessageFlag;
 };
 
+export const shouldClearCacheUponConfigUpdate = (): boolean => {
+    const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov-prismaless');
+    const clearCacheUponConfigUpdateFlag = configuration.get<boolean>('clearCacheUponConfigUpdate', true);
+    return clearCacheUponConfigUpdateFlag;
+};
+
 export const getExternalChecksDir = (): string | undefined => {
     const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('checkov-prismaless');
     const externalChecksDir = configuration.get<string>('externalChecksDir');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,9 +148,9 @@ export const getGitRepoName = async (logger: winston.Logger, filename: string | 
             if (line.startsWith('origin')) {
                 // remove the upstream name from the front and ' (fetch)' or ' (push)' from the back
                 const repoUrl = line.split('\t')[1].split(' ')[0];
-                logger.info('repo url' + repoUrl);
+                logger.info('repo url ' + repoUrl);
                 const repoName = parseRepoName(repoUrl);
-                logger.info('repo name' + repoName);
+                logger.info('repo name ' + repoName);
                 if (repoName) {
                     return repoName;
                 }


### PR DESCRIPTION
Closes #10 [Feature]: List of skipped checks (and closes https://github.com/bridgecrewio/checkov-vscode/issues/125)

This disables the hardcoded `--skip-check BC_LIC*`, ensuring the`skip-check:` from `.checkov.yaml` config file are evaluated as expected if config file defined.

Also adds an extension configuration option that overwrites any checkov.yaml config, similar to frameworks of skip-frameworks.