### PR TITLE
Search upward from file location for config file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -351,7 +351,7 @@ export function activate(context: vscode.ExtensionContext): void {
         try {
             setSyncingStatusBarItem(checkovInstallation?.actualVersion, 'Checkov scanning');
             const filePath = options.fileUri ? options.fileUri.fsPath : editor.document.fileName;
-            const configPath = getConfigFilePath(logger);
+            const configPath = getConfigFilePath(logger, filePath);
 
             if (!checkovInstallation) {
                 logger.error('Checkov is not installed, aborting scan.');

--- a/src/parseCheckovConfig.ts
+++ b/src/parseCheckovConfig.ts
@@ -3,14 +3,51 @@ import { existsSync } from 'fs';
 import { Logger } from 'winston';
 import { getWorkspacePath } from './utils';
 
+export const getConfigFilePath = (logger: Logger, filePath: string): string | undefined => {
+    const baseDir = path.dirname(filePath);
+    logger.debug(`Base dir of file to be scanned: ${baseDir}`);
 
-export const getConfigFilePath = (logger: Logger): string | undefined => {
+    const checkDirs: string[] = [];
     const workspacePath = getWorkspacePath(logger);
+
     if (workspacePath) {
-        const paths =  [path.join(workspacePath, '.checkov.yml'), path.join(workspacePath, '.checkov.yaml')];
-        for (const path of paths) {
-            if(existsSync(path)) return path;
+        const relative = path.relative(workspacePath, filePath);
+        const isInWorkspace = !relative.startsWith('..') && !path.isAbsolute(relative);
+
+        logger.debug(`Workspace path: ${workspacePath}`);
+        logger.debug(`Is file in workspace: ${isInWorkspace}`);
+
+        if (isInWorkspace) {
+            // Search upward from baseDir to workspacePath
+            let currentDir = baseDir;
+            while (currentDir.startsWith(workspacePath)) {
+                checkDirs.push(currentDir);
+                const parentDir = path.dirname(currentDir);
+                if (parentDir === currentDir) break;
+                currentDir = parentDir;
+            }
+        } else {
+            // Only check the base directory
+            checkDirs.push(baseDir);
+        }
+    } else {
+        // No workspace, only check the base directory
+        checkDirs.push(baseDir);
+    }
+
+    for (const dir of checkDirs) {
+        const ymlPath = path.join(dir, '.checkov.yml');
+        const yamlPath = path.join(dir, '.checkov.yaml');
+        if (existsSync(ymlPath)) {
+            logger.debug(`Config file found at: ${ymlPath}`);
+            return ymlPath;
+        }
+        if (existsSync(yamlPath)) {
+            logger.debug(`Config file found at: ${yamlPath}`);
+            return yamlPath;
         }
     }
+
+    logger.debug('No config file found.');
     return undefined;
 };


### PR DESCRIPTION
This code modifies how the plugin locates the checkov config file.  Instead of only looking in the workspace path, this code will look for the config file in the same directory as the file to be scanned and any parent directory up to the workspace path.  If no workspace path is available, it will only look in the same directory as the file to be scanned. 

This change is a result of inconsistent behavior observed across our team. Sometimes the config file would be found and used, while other times it would be ignored.  Our test project repository is laid out like this.  

project/readme.md
project/templates/cloudformation-template.yml
project/templates/.checkov.yaml

Case 1:
When opening the project repository on its own (the only open folder in vscode) and triggering a scan of cloudformation-template.yml, vscode would report the workspace path as 'project'.  In this case with the original code the checkov config file **would not** be found.  

Case 2:
When opening the project repo along with other project repos in the same vscode workspace and triggering a scan of cloudformation-template.yml, vscode would report to the plugin that the workspace path is 'project/templates'.  In this case with the original code the checkov config file **would** be found.  

Moving .checkov.yml to the root of the project repo reversed the results.  

Checkov uses [this logic](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file) to locate the config file. 
- File specified with --config-file
- Directory against which checkov is run. (--directory)
- Current working directory where checkov is called.
- User's home directory.

When checkov is run through this plugin, especially when it is run via Docker, some of these methods are no longer feasible.  This code attempts to resolve that by using the highest preference option, using `--config-file`.  The other options break down for these reasons.
- _Directory against which checkov is run. (--directory)_.  The plugin does not run checkov with the `--directory` option.  Instead it uses the single file option, `-f`.  
- _Current working directory where checkov is called_.  In case 1 above, the config file is not found, because the working directory does not contain the config file.  In case 2, the working directory does contain the config file and checkov would find it here, but the plugin also finds the config file and specifies it to checkov with `--config-file`.
- _User's home directory_.  This option might work when running checkov via python, but when running via Docker this path is not available to checkov.  

The code in this PR attempts for account the variability in vscode's workspace path, by looking for a likely checkov config file in more places, and specifying that file using `--config-file`.  This code has been testing on Linux with the Docker method, and on Windows with the python method.  This code does not fix or add the ability to use config files in the user's home directory.   