### PR TITLE
Properly quote config file path in getpipRunParams

### DIFF
--- a/src/checkov/checkovRunner.ts
+++ b/src/checkov/checkovRunner.ts
@@ -54,7 +54,7 @@ const getDockerRunParams = (logger: Logger, workspaceRoot: string | undefined, f
 };
 
 const getpipRunParams = (configFilePath: string | undefined) => {
-    return configFilePath ? ['--config-file', configFilePath] : [];
+    return configFilePath ? ['--config-file', `"${configFilePath}"`] : [];
 };
 
 const cleanupStdout = (stdout: string) => stdout.replace(/.\[0m/g,''); // Clean docker run ANSI escape chars


### PR DESCRIPTION
This pull request includes a very small change to fix path quoting for checkov's "--config-file" parameter.  It applies the same technique used to quote the "-f" parameter on line 76.  This ensures that both parameters are properly quoted when running checkov in pip mode.  Docker mode is unchanged.