### PR TITLE
fix: honor config file skip-check #22

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,9 @@
         },
         "checkov-prismaless.skipChecks": {
           "title": "Skip Checks",
-          "markdownDescription": "Filter scan to run all checks except those listed (deny list). Add multiple checks using comma separated values \nSetting this configuration property will overide any `skip-check` entry defined in your [checkov config file](https://github.com/bridgecrewio/checkov?tab=readme-ov-file#configuration-using-a-config-file). ",
-          "type": "string"
+          "markdownDescription": "Filter scan to run all checks except those listed (deny list). Add multiple checks using comma separated values. Defaults to `BC_LIC*` to skip license compliance checks.  \n\n**Priority:** If your `.checkov.yaml` config file contains `skip-check`, it will take complete precedence over this VS Code setting. Otherwise, this setting will be used. To rely entirely on your config file, clear this field.",
+          "type": "string",
+          "default": "BC_LIC*"
         }
       }
     }

--- a/src/parseCheckovConfig.ts
+++ b/src/parseCheckovConfig.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { Logger } from 'winston';
 import { getWorkspacePath } from './utils';
 
@@ -13,4 +13,20 @@ export const getConfigFilePath = (logger: Logger): string | undefined => {
         }
     }
     return undefined;
+};
+
+export const configHasSkipCheck = (logger: Logger): boolean => {
+    const configPath = getConfigFilePath(logger);
+    if (!configPath) {
+        return false;
+    }
+
+    try {
+        const configContent = readFileSync(configPath, 'utf8');
+        // Check for both skip-check and skip_check formats (YAML supports both)
+        return /^\s*skip[-_]check\s*:/m.test(configContent);
+    } catch (error) {
+        logger.warn(`Failed to read config file ${configPath}:`, error);
+        return false;
+    }
 };


### PR DESCRIPTION
### Enhancements to `skip-check` handling:

* **Default value for `skip-check` in VS Code settings**:
  - Updated the `checkov-prismaless.skipChecks` setting in `package.json` to include a default value of `BC_LIC*` for skipping license compliance checks. Added a clear priority explanation for how `.checkov.yaml` config files override this setting.

* **Three-tier hierarchy for `skip-check` logic**:
  - Modified the `runCheckovScan` function in `src/checkov/checkovRunner.ts` to implement a hierarchy:
    1. Config file `skip-check` takes precedence.
    2. If not defined in the config file, uses VS Code settings (defaulting to `BC_LIC*`).
    3. Allows config files to completely override VS Code settings.

### New utility function for config file parsing:

* **Added `configHasSkipCheck` function**:
  - Introduced a new function in `src/parseCheckovConfig.ts` to detect whether the `.checkov.yaml` config file contains a `skip-check` or `skip_check` entry. This function reads and parses the config file, handling errors gracefully.

### Codebase improvements:

* **Refactored imports**:
  - Updated imports in `src/parseCheckovConfig.ts` to include `readFileSync` for reading config files.
  - Added the `configHasSkipCheck` import in `src/checkov/checkovRunner.ts` to integrate the new utility function. 

fixes #22 